### PR TITLE
fix(layout): switch next/image with chakra img

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,9 +8,11 @@ module.exports = withPWA({
     dest: "public",
     register: true,
   },
-  images: {
-    domains: ["api.producthunt.com"],
-  },
+  // images: {
+  //   domains: ["api.producthunt.com"],
+  //   // added in next.js 12.1.0 https://nextjs.org/docs/api-reference/next/image#dangerously-allow-svg
+  //   dangerouslyAllowSVG: true,
+  // },
   reactStrictMode: true,
   webpack: (config, { dev, isServer }) => {
     // Replace React with Preact only in client production build

--- a/src/lib/components/layout/Badges.tsx
+++ b/src/lib/components/layout/Badges.tsx
@@ -1,5 +1,4 @@
-import { Grid, Link, useColorMode } from "@chakra-ui/react";
-import Image from "next/image";
+import { Grid, Link, Image, useColorMode } from "@chakra-ui/react";
 
 const Badges = () => {
   const { colorMode } = useColorMode();


### PR DESCRIPTION
problem: spiking serverless function error related to image (badges in app menu as it uses external svg)
cause: nextjs v12.1 image config https://nextjs.org/docs/api-reference/next/image#dangerously-allow-svg